### PR TITLE
投稿保存機能の実装

### DIFF
--- a/__tests__/app/api/posts/route.test.ts
+++ b/__tests__/app/api/posts/route.test.ts
@@ -45,8 +45,16 @@ describe("POST /api/posts", () => {
       const response = await POST(request);
       const data = await response.json();
 
+      const expectedPhotos = [
+        {
+          id: "1",
+          imageUrl: "https://example.com/image1.jpg",
+          exifData: undefined,
+        },
+      ];
+
       expect(response.status).toBe(200);
-      expect(data).toEqual({ data: mockPosts, error: null });
+      expect(data).toEqual({ data: expectedPhotos, error: null });
       expect(getPosts).toHaveBeenCalledWith(20, 0);
     });
 

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -27,13 +27,20 @@ export async function POST(request: NextRequest) {
     }
 
     // Server Action を呼び出し
-    const { data, error } = await getPosts(limit, offset);
+    const { data: posts, error } = await getPosts(limit, offset);
 
     if (error) {
       return NextResponse.json({ data: null, error }, { status: 500 });
     }
 
-    return NextResponse.json({ data, error: null });
+    // PhotoCardProps形式のデータを作成
+    const photos = posts?.map((post) => ({
+      id: post.id,
+      imageUrl: post.imageUrl,
+      exifData: post.exifData || undefined,
+    }));
+
+    return NextResponse.json({ data: photos, error: null });
   } catch (err) {
     console.error("API Error:", err);
     return NextResponse.json(

--- a/app/page-client.tsx
+++ b/app/page-client.tsx
@@ -36,6 +36,8 @@ export function PageClient({ initialPhotos }: PageClientProps) {
   ) => {
     // 即座にモーダルを表示（楽観的UI更新）
     setSelectedPostId(photoId);
+    // 保存状態をリセット（前の投稿の状態が残らないように）
+    setInitialIsSaved(false);
 
     // 初期表示用に既存のPhotoCardデータから仮のPostデータを作成
     const tempPost: Post = {

--- a/components/post-detail/post-detail-modal.tsx
+++ b/components/post-detail/post-detail-modal.tsx
@@ -27,6 +27,11 @@ export function PostDetailModal({
   const [isMobile, setIsMobile] = useState(false);
   const [showLoginPrompt, setShowLoginPrompt] = useState(false);
 
+  // initialIsSavedの変更を監視
+  useEffect(() => {
+    setIsSaved(initialIsSaved);
+  }, [initialIsSaved]);
+
   // モバイル判定
   useEffect(() => {
     const checkMobile = () => {


### PR DESCRIPTION
## 概要
投稿詳細画面での保存機能を実装しました。

## 変更内容

### 実装した機能
- 投稿詳細画面での保存/保存解除機能
- 保存状態の表示（ハートアイコン）
- 未認証ユーザーへのログイン促進モーダル表示
- 保存状態の永続化（Supabaseデータベース）

### 技術的な実装
- **API**: `/api/saves/toggle` で保存状態のトグル処理
- **Server Actions**: `checkIsSaved`, `checkMultipleSaves` で保存状態取得
- **Database**: `saves` テーブルで保存データを管理（RLSポリシー適用済み）
- **State Management**: `PostDetailModal`で`useEffect`による状態同期を実装

### リファクタリング
- 一覧画面の保存アイコン表示を削除（詳細画面のみに集約）
- デバッグログの削除
- テストを新しいAPI構造に合わせて更新

## データベーススキーマ

### savesテーブル
- `id`: UUID（主キー）
- `user_id`: UUID（users.id参照、CASCADE削除）
- `post_id`: UUID（posts.id参照、CASCADE削除）
- `created_at`: TIMESTAMP
- ユニーク制約: (user_id, post_id)

## テスト結果
✅ 全テスト通過（67テスト）
✅ ビルド成功
✅ 型チェック通過

## スクリーンショット
（必要に応じて追加）

## 備考
- 保存機能は詳細画面でのみ利用可能
- 未認証ユーザーは保存ボタンをクリックするとログイン促進モーダルが表示される
- ブラウザバック時の一覧画面での状態更新は非対応（サーバーコンポーネントの制限）

🤖 Generated with [Claude Code](https://claude.com/claude-code)