### PR TITLE
feat: Pull-to-Refresh機能を実装 (#34)

### DIFF
--- a/components/ui/pull-to-refresh.tsx
+++ b/components/ui/pull-to-refresh.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { usePullToRefresh } from "@/hooks/use-pull-to-refresh";
+import { Loader2 } from "lucide-react";
+
+interface PullToRefreshProps {
+  onRefresh: () => Promise<void>;
+  children: React.ReactNode;
+  disabled?: boolean;
+  threshold?: number;
+  topOffset?: number; // ヘッダーの高さなど、上からのオフセット（px）
+}
+
+/**
+ * Pull-to-Refresh機能を提供するコンポーネント
+ * モバイル/タッチデバイスでのみ動作します
+ */
+export function PullToRefresh({
+  onRefresh,
+  children,
+  disabled = false,
+  threshold = 80,
+  topOffset = 0,
+}: PullToRefreshProps) {
+  const { isPulling, isRefreshing, pullDistance } = usePullToRefresh({
+    onRefresh,
+    disabled,
+    threshold,
+  });
+
+  // ローディングアイコンの表示状態
+  const showLoader = isPulling || isRefreshing;
+
+  // ローディングアイコンの不透明度（プル距離に応じて変化）
+  const loaderOpacity = Math.min(pullDistance / threshold, 1);
+
+  // ローディングアイコンの回転角度（プル距離に応じて変化）
+  const loaderRotation = isRefreshing ? 0 : (pullDistance / threshold) * 360;
+
+  return (
+    <div className="relative">
+      {/* ローディングインジケーター */}
+      <AnimatePresence>
+        {showLoader && (
+          <motion.div
+            className="fixed left-0 right-0 z-0 flex justify-center"
+            style={{
+              top: topOffset + 8, // ヘッダーのすぐ下に固定
+            }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: loaderOpacity }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <div className="rounded-full bg-background p-2 shadow-lg ring-1 ring-border">
+              <Loader2
+                className="h-6 w-6 text-primary"
+                style={{
+                  animation: isRefreshing ? "spin 1s linear infinite" : "none",
+                  transform: isRefreshing
+                    ? undefined
+                    : `rotate(${loaderRotation}deg)`,
+                  transition: isRefreshing
+                    ? undefined
+                    : "transform 0.1s ease-out",
+                }}
+              />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* コンテンツ */}
+      <motion.div
+        className="relative z-10"
+        animate={{
+          y: isRefreshing
+            ? 48 // リフレッシュ中はローディングアイコンの下で固定
+            : isPulling
+              ? pullDistance * 0.8
+              : 0,
+        }}
+        transition={{
+          type: "spring",
+          stiffness: 300,
+          damping: 30,
+        }}
+      >
+        {children}
+      </motion.div>
+    </div>
+  );
+}

--- a/hooks/use-pull-to-refresh.ts
+++ b/hooks/use-pull-to-refresh.ts
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+
+interface UsePullToRefreshOptions {
+  onRefresh: () => Promise<void>;
+  disabled?: boolean;
+  threshold?: number;
+  resistance?: number;
+}
+
+interface UsePullToRefreshReturn {
+  isPulling: boolean;
+  isRefreshing: boolean;
+  pullDistance: number;
+}
+
+/**
+ * Pull-to-Refresh機能を提供するカスタムフック
+ * モバイル/タッチデバイスでのみ動作します
+ */
+export function usePullToRefresh({
+  onRefresh,
+  disabled = false,
+  threshold = 80,
+  resistance = 2.5,
+}: UsePullToRefreshOptions): UsePullToRefreshReturn {
+  const [isPulling, setIsPulling] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [pullDistance, setPullDistance] = useState(0);
+  const touchStartY = useRef<number>(0);
+  const scrollableRef = useRef<number>(0);
+
+  // モバイルデバイス判定
+  const isMobile = useCallback(() => {
+    return "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  }, []);
+
+  // タッチ開始
+  const handleTouchStart = useCallback(
+    (e: TouchEvent) => {
+      if (disabled || !isMobile() || isRefreshing) return;
+
+      // スクロール位置が最上部にある場合のみ有効
+      const scrollTop = window.scrollY || document.documentElement.scrollTop;
+      if (scrollTop === 0) {
+        touchStartY.current = e.touches[0].clientY;
+        scrollableRef.current = scrollTop;
+      }
+    },
+    [disabled, isMobile, isRefreshing]
+  );
+
+  // タッチ移動
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      if (disabled || !isMobile() || isRefreshing) return;
+
+      const scrollTop = window.scrollY || document.documentElement.scrollTop;
+
+      // スクロール位置が最上部でない場合は処理しない
+      if (scrollTop > 0) {
+        setIsPulling(false);
+        setPullDistance(0);
+        return;
+      }
+
+      const touchCurrentY = e.touches[0].clientY;
+      const distance = touchCurrentY - touchStartY.current;
+
+      // 下方向へのスワイプのみ処理
+      if (distance > 0 && scrollTop === 0) {
+        // スクロール位置が0の場合のみpreventDefaultを呼び出す（スクロール開始前）
+        e.preventDefault();
+
+        setIsPulling(true);
+
+        // 抵抗感を加えてプル距離を計算
+        const adjustedDistance = distance / resistance;
+        setPullDistance(Math.min(adjustedDistance, threshold * 2.5));
+      }
+    },
+    [disabled, isMobile, isRefreshing, threshold, resistance]
+  );
+
+  // タッチ終了
+  const handleTouchEnd = useCallback(async () => {
+    if (disabled || !isMobile() || isRefreshing) return;
+
+    if (pullDistance >= threshold) {
+      // 閾値を超えたらリフレッシュ開始
+      setIsRefreshing(true);
+      setIsPulling(false);
+      setPullDistance(threshold); // 固定位置に表示
+
+      const startTime = Date.now(); // リフレッシュ開始時刻
+
+      try {
+        await onRefresh();
+      } catch (error) {
+        console.error("Failed to refresh:", error);
+      }
+
+      // 最低0.7秒は表示する
+      const elapsed = Date.now() - startTime;
+      const minDuration = 700; // 0.7秒
+      if (elapsed < minDuration) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, minDuration - elapsed)
+        );
+      }
+
+      setIsRefreshing(false);
+      setPullDistance(0);
+    } else {
+      // 閾値未満なら元に戻す
+      setIsPulling(false);
+      setPullDistance(0);
+    }
+
+    touchStartY.current = 0;
+  }, [disabled, isMobile, isRefreshing, pullDistance, threshold, onRefresh]);
+
+  useEffect(() => {
+    if (!isMobile() || disabled) return;
+
+    document.addEventListener("touchstart", handleTouchStart, {
+      passive: true,
+    });
+    document.addEventListener("touchmove", handleTouchMove, { passive: false });
+    document.addEventListener("touchend", handleTouchEnd, { passive: true });
+
+    return () => {
+      document.removeEventListener("touchstart", handleTouchStart);
+      document.removeEventListener("touchmove", handleTouchMove);
+      document.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [handleTouchStart, handleTouchMove, handleTouchEnd, isMobile, disabled]);
+
+  return {
+    isPulling,
+    isRefreshing,
+    pullDistance,
+  };
+}


### PR DESCRIPTION
## 概要

モバイル/タッチデバイスで画面を下にスワイプしてリロードできるPull-to-Refresh機能を実装しました。

Closes #34

## 実装内容

### 新規作成

**hooks/use-pull-to-refresh.ts**
- タッチイベント監視とプル距離計算
- モバイルデバイス判定
- 閾値判定（80px）とリロードトリガー
- 抵抗感のあるスムーズなプル動作

**components/ui/pull-to-refresh.tsx**
- 再利用可能なPull-to-Refreshラッパーコンポーネント
- framer-motionによるローディングアニメーション
- プル距離に応じた視覚的フィードバック

### 統合

**app/page-client.tsx（メインページ）**
- 初期20件のみリロード（パフォーマンス最適化）
- 無限スクロール状態のリセット
- モーダル表示中・検索モード中は無効化

**app/me/page-client.tsx（プロフィールページ）**
- アクティブなタブのみリロード（投稿 or 保存）
- 各タブの無限スクロール状態をリセット
- モーダル表示中は無効化

## 機能詳細

### 動作仕様
- **対応デバイス**: モバイル/タッチデバイスのみ
- **表示位置**: ヘッダーのすぐ下に固定（背後レイヤー）
- **スワイプ距離**: 最大200px × 0.8 = 160px移動
- **リフレッシュ閾値**: 80px
- **最小ローディング時間**: 0.7秒（視覚的フィードバック確保）

### UX最適化
- ローディングアイコンは投稿一覧の背後に表示（重なり防止）
- リフレッシュ中はローディングアイコンの下で一時停止
- リフレッシュ完了後、スムーズに元の位置に戻る
- スワイプ中はブラウザのデフォルトスクロールを防止

## テストプラン

- [ ] メインページでPull-to-Refreshが動作する
- [ ] プロフィールページ（投稿タブ）でPull-to-Refreshが動作する
- [ ] プロフィールページ（保存タブ）でPull-to-Refreshが動作する
- [ ] リロード後にデータが正しく更新される
- [ ] 無限スクロール状態がリセットされる
- [ ] モーダル表示中はPull-to-Refreshが無効化される
- [ ] 検索モード中はPull-to-Refreshが無効化される
- [ ] デスクトップでは動作しない
- [ ] ローディングアイコンが投稿一覧の背後に表示される
- [ ] 最低0.7秒間ローディングアイコンが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)