### PR TITLE
X共有機能の実装

### DIFF
--- a/components/post-detail/post-actions-menu.tsx
+++ b/components/post-detail/post-actions-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MoreHorizontal, Trash2 } from "lucide-react";
+import { MoreHorizontal, Trash2, Share2 } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,9 +10,13 @@ import {
 
 interface PostActionsMenuProps {
   onDeleteClick: () => void;
+  onShareToXClick?: () => void;
 }
 
-export function PostActionsMenu({ onDeleteClick }: PostActionsMenuProps) {
+export function PostActionsMenu({
+  onDeleteClick,
+  onShareToXClick,
+}: PostActionsMenuProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -24,6 +28,12 @@ export function PostActionsMenu({ onDeleteClick }: PostActionsMenuProps) {
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
+        {onShareToXClick && (
+          <DropdownMenuItem onClick={onShareToXClick}>
+            <Share2 className="mr-2 h-4 w-4" />
+            <span>Xで共有する</span>
+          </DropdownMenuItem>
+        )}
         <DropdownMenuItem
           className="text-red-600 focus:text-red-600"
           onClick={onDeleteClick}

--- a/components/post-detail/share-text-preview-modal.tsx
+++ b/components/post-detail/share-text-preview-modal.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Copy, Check } from "lucide-react";
+
+interface ShareTextPreviewModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialText: string;
+}
+
+export function ShareTextPreviewModal({
+  open,
+  onOpenChange,
+  initialText,
+}: ShareTextPreviewModalProps) {
+  const [text, setText] = useState(initialText);
+  const [copied, setCopied] = useState(false);
+
+  // initialTextが変更されたらtextを更新
+  useEffect(() => {
+    if (open && initialText) {
+      setText(initialText);
+      setCopied(false);
+    }
+  }, [open, initialText]);
+
+  // テキストが変更されたときに状態を更新
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+    setCopied(false); // テキストが変更されたらコピー状態をリセット
+  };
+
+  // クリップボードにコピー
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000); // 2秒後にリセット
+    } catch (error) {
+      console.error("クリップボードへのコピーに失敗しました:", error);
+    }
+  };
+
+  // モーダルが開かれたときに初期テキストをリセット
+  const handleOpenChange = (newOpen: boolean) => {
+    onOpenChange(newOpen);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="sm:max-w-[500px]"
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        onPointerDownOutside={(e) => {
+          // テキストエリアやボタンをクリックしてもモーダルが閉じないようにする
+          e.preventDefault();
+        }}
+        onInteractOutside={(e) => {
+          // 外側クリック時にモーダルを閉じる
+          const target = e.target as HTMLElement;
+          // DialogContent内の要素の場合は閉じない
+          if (target.closest('[role="dialog"]')) {
+            e.preventDefault();
+          }
+        }}
+      >
+        <DialogHeader>
+          <DialogTitle>X投稿用テキスト</DialogTitle>
+          <DialogDescription>
+            テキストを編集して、コピーボタンでクリップボードにコピーできます
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <Textarea
+            value={text}
+            onChange={handleTextChange}
+            className="min-h-[150px] resize-none font-mono text-sm"
+            placeholder="テキストを入力..."
+          />
+          <Button
+            onClick={handleCopy}
+            className="w-full"
+            variant={copied ? "outline" : "default"}
+          >
+            {copied ? (
+              <>
+                <Check className="mr-2 h-4 w-4" />
+                コピーしました
+              </>
+            ) : (
+              <>
+                <Copy className="mr-2 h-4 w-4" />
+                クリップボードにコピー
+              </>
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## 概要
投稿詳細画面にX共有機能を追加しました。

## 変更内容

### 機能追加
- **X共有メニュー項目**: 投稿者本人の投稿詳細画面の「...」メニューに「Xで共有する」を追加
- **テキストプレビューモーダル**: EXIF情報とハッシュタグを含むテキストをプレビュー・編集・コピー可能
- **画像自動ダウンロード**: 共有ボタン押下時に画像を自動ダウンロード
- **カメラモデル名変換**: SONYカメラのモデル名を読みやすい形式に変換（例: ILCE-7M3 → α7III）

### 実装詳細
- `components/post-detail/post-actions-menu.tsx`: Share2アイコンとメニュー項目を追加
- `components/post-detail/share-text-preview-modal.tsx`: テキストプレビューモーダルコンポーネントを新規作成
- `components/post-detail/post-detail-modal.tsx`: X共有ハンドラーとテキスト生成ロジックを実装

### テキストフォーマット
```
カメラ：α7III
レンズ：FE 24-105mm F4 G OSS

ISO:125
F値：9
SS:1/200

#カメラ初心者
#写真初心者
#カメラ好きと繋がりたい
```

## 技術的な制約
- X Web IntentとWeb Share APIの制約により、画像とテキストを同時にX投稿フォームに渡すことができないため、画像ダウンロード+テキストコピーの方式を採用
- 将来的にリリース時に実装方式の変更を検討予定（別issueで管理）

## テストプラン
- [ ] ログインユーザーとして自分の投稿詳細画面を開く
- [ ] 「...」メニューに「Xで共有する」が表示されることを確認
- [ ] 「Xで共有する」をクリック
- [ ] 画像がダウンロードされることを確認
- [ ] テキストプレビューモーダルが表示されることを確認
- [ ] EXIF情報が正しくフォーマットされていることを確認
- [ ] テキストを編集できることを確認
- [ ] 「クリップボードにコピー」ボタンでコピーできることを確認
- [ ] コピー後「コピーしました」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)