### PR TITLE
fix: 本番サイトURLをshotsharing.meに設定

### DIFF
--- a/lib/constants/site.ts
+++ b/lib/constants/site.ts
@@ -2,11 +2,7 @@ export const siteConfig = {
   name: "Shot Sharing",
   description:
     "写真の作例を共有し、撮影設定から類似写真を検索できるAIフォトシェアリングプラットフォーム",
-  url:
-    process.env.NEXT_PUBLIC_SITE_URL ||
-    (process.env.VERCEL_URL
-      ? `https://${process.env.VERCEL_URL}`
-      : "http://localhost:3000"),
+  url: process.env.NEXT_PUBLIC_SITE_URL || "https://shotsharing.me",
   ogImage: "/og-image.png",
   creator: "Shot Sharing Team",
   keywords: [


### PR DESCRIPTION
## Summary
- X共有時のURLがlocalhostになっていた問題を修正
- siteConfig.urlのデフォルト値を`https://shotsharing.me`に設定

## Test plan
- [x] 型チェック通過
- [ ] 本番環境でX共有URLが正しく`https://shotsharing.me/posts/...`になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)