### PR TITLE
fix: FAB展開時の画像添付アイコンを一時的に削除

### DIFF
--- a/components/layout/search-fab.tsx
+++ b/components/layout/search-fab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion, AnimatePresence } from "framer-motion";
-import { ImageIcon, Search, Send } from "lucide-react";
+import { Search, Send } from "lucide-react";
 import { useState, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 
@@ -199,17 +199,6 @@ export function SearchFAB({
                 className="flex-1 bg-transparent outline-none placeholder:text-muted-foreground"
                 autoFocus
               />
-
-              {/* 画像添付ボタン */}
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="h-10 w-10 shrink-0"
-                onMouseDown={(e) => e.preventDefault()}
-              >
-                <ImageIcon className="h-5 w-5" />
-              </Button>
 
               {/* 送信ボタン */}
               <Button


### PR DESCRIPTION
## Summary
- FAB展開時に表示されていた画像添付アイコン（送信ボタン左）を削除
- 画像検索機能は後で実装予定

## 変更内容
- `components/layout/search-fab.tsx`: ImageIconボタンを削除

## Test plan
- [ ] FABをクリックして展開し、画像添付アイコンが表示されないことを確認
- [ ] 送信ボタンが正常に機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)