### PR TITLE
fix: ナビゲーション改善とSearchFABの重なり解消

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -79,6 +79,27 @@ excluded_tools: []
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-
+# the name by which the project can be referenced within Serena
 project_name: "shot-sharing"
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
 included_optional_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []

--- a/app/actions/posts.ts
+++ b/app/actions/posts.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidatePath, updateTag } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import { ExifData } from "@/lib/types/exif";
 import { extractExifData } from "@/lib/image/exif";
@@ -363,7 +363,8 @@ export async function createPost(formData: FormData) {
     // キャッシュを再検証
     revalidatePath("/");
     revalidatePath("/me");
-    revalidateTag("posts", "default"); // 投稿一覧のキャッシュを無効化
+    updateTag("posts"); // 投稿一覧のキャッシュを無効化
+    updateTag("profile"); // プロフィールページのキャッシュも無効化
 
     return {
       success: true,
@@ -628,7 +629,8 @@ export async function deletePost(postId: string) {
     revalidatePath("/");
     revalidatePath("/me");
     revalidatePath(`/users/${user.id}`);
-    revalidateTag("posts", "default"); // 投稿一覧のキャッシュを無効化
+    updateTag("posts"); // 投稿一覧のキャッシュを無効化
+    updateTag("profile"); // プロフィールページのキャッシュも無効化
 
     return { success: true };
   } catch (error) {

--- a/app/actions/profiles.ts
+++ b/app/actions/profiles.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidatePath, updateTag } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
 import {
   uploadAvatarToStorage,
@@ -155,7 +155,7 @@ export async function updateProfile(formData: FormData) {
 
     // キャッシュをクリア
     revalidatePath("/me");
-    revalidateTag("profile", "default"); // プロフィールキャッシュを無効化
+    updateTag("profile"); // プロフィールキャッシュを無効化
 
     return { success: true, error: null };
   } catch (error) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -99,11 +99,6 @@ const getCachedPosts = unstable_cache(
 );
 
 export default async function Home() {
-  console.log(
-    "🏠 [DEBUG] Home page レンダリング開始:",
-    new Date().toISOString()
-  );
-
   // サーバー側で認証状態を取得（キャッシュしない）
   const supabase = await createClient();
   const {
@@ -111,14 +106,7 @@ export default async function Home() {
   } = await supabase.auth.getUser();
 
   // キャッシュから投稿データを取得（30秒間キャッシュ）
-  console.log("📡 [DEBUG] getCachedPosts呼び出し前:", new Date().toISOString());
   const { data: posts, error } = await getCachedPosts();
-  console.log(
-    "📡 [DEBUG] getCachedPosts完了:",
-    new Date().toISOString(),
-    "件数:",
-    posts?.length || 0
-  );
 
   // エラーハンドリング
   if (error) {
@@ -134,11 +122,10 @@ export default async function Home() {
       exifData: post.exifData || undefined,
     })) || [];
 
-  console.log("📤 [DEBUG] PageClientに渡すphotos:", photos.length, "件");
   return (
     <>
       <WebSiteJsonLd />
-      <PageClient initialPhotos={photos} initialUser={user} />
+      <PageClient key="home" initialPhotos={photos} initialUser={user} />
     </>
   );
 }

--- a/components/layout/global-bottom-nav.tsx
+++ b/components/layout/global-bottom-nav.tsx
@@ -314,15 +314,11 @@ export function GlobalBottomNav() {
   };
 
   const handleHomeClick = () => {
-    // 既にホームにいる場合は何もしない
-    if (isHome) return;
-
     // /meページから離れる場合、両方のアイコンを同時にアニメーション
     if (isMe) {
       setIsNavigatingFromMe(true); // プロフィールアイコン: 黒→白
       setIsNavigatingToHome(true); // ホームアイコン: 白→黒
-      // アニメーション完了を待ってからフルページナビゲーション
-      // ※ router.push()ではSoft Navigationの不具合でページコンテンツが更新されないため
+      // アニメーション完了を待ってからハードナビゲーション（パラレルルートをリセット）
       setTimeout(() => {
         window.location.href = "/";
       }, 300);
@@ -356,15 +352,11 @@ export function GlobalBottomNav() {
 
   const handleRightClick = () => {
     if (user) {
-      // 既にマイページにいる場合は何もしない
-      if (isMe) return;
-
       // ホームから離れる場合、両方のアイコンを同時にアニメーション
       if (isHome) {
         setIsNavigatingFromHome(true); // ホームアイコン: 黒→白
         setIsNavigatingToMe(true); // プロフィールアイコン: 白→黒
-        // アニメーション完了を待ってからフルページナビゲーション
-        // ※ router.push()ではSoft Navigationの不具合でページコンテンツが更新されないため
+        // アニメーション完了を待ってからハードナビゲーション（パラレルルートをリセット）
         setTimeout(() => {
           window.location.href = "/me";
         }, 300);

--- a/components/layout/search-fab.tsx
+++ b/components/layout/search-fab.tsx
@@ -193,9 +193,7 @@ export function SearchFAB({
   return (
     <div
       className={`fixed left-0 right-0 z-[60] flex flex-col items-center px-4 transition-all duration-200 ${
-        isSmallScreenFocused
-          ? "bottom-0 pb-2"
-          : "bottom-20 xl:bottom-4 xl:left-16"
+        isSmallScreenFocused ? "bottom-0 pb-2" : "bottom-20 xl:left-16"
       }`}
     >
       {/* 質問例バッジ（展開時のみ表示、チャットがない場合のみ） */}


### PR DESCRIPTION
## Summary
- 1280px以上でSearchFABとボトムナビが重なる問題を修正（`xl:bottom-4`を削除）
- `revalidateTag`を`updateTag`に移行（Next.js 16対応）
- 投稿作成・削除時にプロフィールキャッシュも無効化するよう追加
- ボトムナビのナビゲーションをハードナビゲーション化（パラレルルートのリセット対応）
- マイページの`dynamic="force-dynamic"`を削除しデータ取得を関数に整理
- デバッグ用console.logを削除

## Test plan
- [ ] 1280px未満: SearchFABがボトムナビの上に表示されること
- [ ] 1280px以上: SearchFABがボトムナビと重ならないこと
- [ ] 1280px以上: SearchFABのデスクトップサイドバー分の左オフセットが維持されること
- [ ] ホーム⇔マイページのナビゲーションが正常に動作すること
- [ ] 投稿作成・削除後にキャッシュが適切に無効化されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)